### PR TITLE
Fix xretrace context menu closing after any key pressed.

### DIFF
--- a/xretrace/xretrace.e
+++ b/xretrace/xretrace.e
@@ -1847,8 +1847,9 @@ static void retrace_steps_event_loop2(boolean list_selector, int popup_wid, bool
             {
                // 'ESC' seems to be registering as some keypresses when first starting
                // this event loop as well as after any key is hit. Filter out any occurring in a
-               // short time from the beginning as well as after any key (except ESC) is pressed.
+               // short time from the beginning as well as after any key is pressed.
                // See: https://community.slickedit.com/index.php/topic,16598.msg67541.html#msg67541
+               //      https://community.slickedit.com/index.php/topic,16598.msg71577.html#msg71577
                continue;
             }
             //dsay("Event loop ESC return");

--- a/xretrace/xretrace.e
+++ b/xretrace/xretrace.e
@@ -1556,8 +1556,6 @@ static void retrace_steps_event_loop2(boolean list_selector, int popup_wid, bool
       same_buffer_name = ip2->buf_name;
    }
 
-   boolean got_esc = false;
-
    while (true) {
       lpos = dlist_get_distance(iter, true);
       xretrace_item * ip = (xretrace_item*)dlist_getp(iter);
@@ -1616,12 +1614,7 @@ static void retrace_steps_event_loop2(boolean list_selector, int popup_wid, bool
       // make numpad keys work properly
       int orig_auto_map_pad_keys=_default_option(VSOPTION_AUTO_MAP_PAD_KEYS);
       _default_option(VSOPTION_AUTO_MAP_PAD_KEYS,0);
-      double startTime;
-      if ( !got_esc )
-      {
-         startTime = (double)_time('B');
-      }
-      got_esc = false;
+      double startTime = (double)_time('B');
       _str key = get_event('N');   // refresh screen and get a key
       _str keyt = event2name(key);
       _default_option(VSOPTION_AUTO_MAP_PAD_KEYS,orig_auto_map_pad_keys);
@@ -1849,7 +1842,6 @@ static void retrace_steps_event_loop2(boolean list_selector, int popup_wid, bool
             iter = dlist_begin(*list_ptr);
             break;
          case 'ESC' :
-            got_esc = true;
             double curTime = (double)_time('B');
             if ( (curTime - startTime) < 500)
             {

--- a/xretrace/xretrace.e
+++ b/xretrace/xretrace.e
@@ -1556,7 +1556,7 @@ static void retrace_steps_event_loop2(boolean list_selector, int popup_wid, bool
       same_buffer_name = ip2->buf_name;
    }
 
-   double startTime = (double)_time('B');
+   boolean got_esc = false;
 
    while (true) {
       lpos = dlist_get_distance(iter, true);
@@ -1616,6 +1616,12 @@ static void retrace_steps_event_loop2(boolean list_selector, int popup_wid, bool
       // make numpad keys work properly
       int orig_auto_map_pad_keys=_default_option(VSOPTION_AUTO_MAP_PAD_KEYS);
       _default_option(VSOPTION_AUTO_MAP_PAD_KEYS,0);
+      double startTime;
+      if ( !got_esc )
+      {
+         startTime = (double)_time('B');
+      }
+      got_esc = false;
       _str key = get_event('N');   // refresh screen and get a key
       _str keyt = event2name(key);
       _default_option(VSOPTION_AUTO_MAP_PAD_KEYS,orig_auto_map_pad_keys);
@@ -1843,14 +1849,17 @@ static void retrace_steps_event_loop2(boolean list_selector, int popup_wid, bool
             iter = dlist_begin(*list_ptr);
             break;
          case 'ESC' :
+            got_esc = true;
             double curTime = (double)_time('B');
             if ( (curTime - startTime) < 500)
             {
                // 'ESC' seems to be registering as some keypresses when first starting
-               // this event loop. Filter out any occurring in a short time from the beginning
+               // this event loop as well as after any key is hit. Filter out any occurring in a
+               // short time from the beginning as well as after any key (except ESC) is pressed.
                // See: https://community.slickedit.com/index.php/topic,16598.msg67541.html#msg67541
                continue;
             }
+            //dsay("Event loop ESC return");
             // exit back where we started
             edit('+Q +BI ' :+ start_buf_id);
             message('');  // clear


### PR DESCRIPTION
The issue is that SlickEdit thinks ESC was pressed after pressing
any key so filter out any ESC presses for 500msec after any key
is pressed.